### PR TITLE
Make inlay hints highlight a dimmer comment shade

### DIFF
--- a/lua/solarized/themes/default/lsp.lua
+++ b/lua/solarized/themes/default/lsp.lua
@@ -10,9 +10,9 @@ return function(c)
   set_hl('LspReferenceWrite', { link = 'Visual' }) -- used for highlighting "write" references
 
   if vim.o.background == 'dark' then
-    set_hl('LspInlayHint', { fg = darken(c.yellow, 20) }) -- used for highlighting inlay hints
+    set_hl('LspInlayHint', { fg = darken(c.base01, 30) }) -- used for highlighting inlay hints
   else
-    set_hl('LspInlayHint', { fg = lighten(c.yellow, 20) })
+    set_hl('LspInlayHint', { fg = lighten(c.base01, 30) })
   end
 
   -- if you want to me to enable the highlight groups bellow, please send a screenshot for me to see how

--- a/lua/solarized/themes/default/lsp.lua
+++ b/lua/solarized/themes/default/lsp.lua
@@ -10,7 +10,7 @@ return function(c)
   set_hl('LspReferenceWrite', { link = 'Visual' }) -- used for highlighting "write" references
 
   if vim.o.background == 'dark' then
-    set_hl('LspInlayHint', { fg = darken(c.base01, 30) }) -- used for highlighting inlay hints
+    set_hl('LspInlayHint', { fg = c.base01 }) -- used for highlighting inlay hints
   else
     set_hl('LspInlayHint', { fg = lighten(c.base01, 30) })
   end

--- a/lua/solarized/themes/neo/lsp.lua
+++ b/lua/solarized/themes/neo/lsp.lua
@@ -10,9 +10,9 @@ return function(c)
   set_hl('LspReferenceWrite', { link = 'Visual' }) -- used for highlighting "write" references
 
   if vim.o.background == 'dark' then
-    set_hl('LspInlayHint', { fg = darken(c.yellow, 20) }) -- used for highlighting inlay hints
+    set_hl('LspInlayHint', { fg = darken(c.base01, 30) }) -- used for highlighting inlay hints
   else
-    set_hl('LspInlayHint', { fg = lighten(c.yellow, 20) })
+    set_hl('LspInlayHint', { fg = lighten(c.base01, 30) })
   end
 
   -- if you want to me to enable the highlight groups bellow, please send a screenshot for me to see how

--- a/lua/solarized/themes/neo/lsp.lua
+++ b/lua/solarized/themes/neo/lsp.lua
@@ -10,7 +10,7 @@ return function(c)
   set_hl('LspReferenceWrite', { link = 'Visual' }) -- used for highlighting "write" references
 
   if vim.o.background == 'dark' then
-    set_hl('LspInlayHint', { fg = darken(c.base01, 30) }) -- used for highlighting inlay hints
+    set_hl('LspInlayHint', { fg = c.base01 }) -- used for highlighting inlay hints
   else
     set_hl('LspInlayHint', { fg = lighten(c.base01, 30) })
   end


### PR DESCRIPTION
The light yellow it was previously set to was not distinguishable enough from surrounding real code.

See: issue #81.

Before: 
![Screenshot 2024-06-10 at 6 43 56 PM](https://github.com/maxmx03/solarized.nvim/assets/157527329/55caa508-7317-4906-b20c-8db6795e9dca)

After: 
![Screenshot 2024-06-10 at 7 11 56 PM](https://github.com/maxmx03/solarized.nvim/assets/157527329/d6db5b90-cc0c-4f7c-b085-3075c66b3880)
